### PR TITLE
swap out os.rename for shutil.move as it can handle diff filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Contact" below to reach the author.
 
 # Usage
 
-```csv2parquet CSV_INPUT PARQUET_OUTPUT [--column-map ...] [--types ...] ```
+```csv2parquet CSV_INPUT PARQUET_OUTPUT [--column-map ...] [--types ...] [--delimiter <delimiter>]```
 
 `csv_input` is a CSV file, whose first line defines the column names.
 `parquet_output` is the Parquet output (i.e., directory in which one
@@ -116,7 +116,6 @@ differently ("python" for 2.7, and "python3" for 3.x). So you can
 In terms of priority:
 
  * Adding certain important features, including:
-   - delimiters other than commas
    - CSV files without header lines
  * Running `csv2parquet` on Windows
 

--- a/csv2parquet
+++ b/csv2parquet
@@ -262,7 +262,7 @@ class DrillScript:
             raise DrillScriptError(proc.returncode)
 
         # publish resulting output parquet file
-        os.rename(self.drill.location.full_path('parquet_tmp_output'), self.parquet_output)
+        shutil.move(self.drill.location.full_path('parquet_tmp_output'), self.parquet_output)
 
 # helper functions
 def get_args():

--- a/csv2parquet
+++ b/csv2parquet
@@ -23,6 +23,9 @@ column names:
 To provide types for columns, use --types:
   csv2parquet data.csv data.parquet --types "CSV Column Name" "INT"
 
+To provide a custom delimiter, use --delimiter:
+  csv2parquet data.tsv data.parquet --delimiter $'\t'
+
 See documentation (README.md in the source repo) for more information.
 '''.strip()
 
@@ -136,17 +139,18 @@ class Columns:
         return iter(self.items)
         
 class CsvSource:
-    def __init__(self, path: str, name_map: dict = None, type_map: dict = None):
+    def __init__(self, path: str, name_map: dict = None, type_map: dict = None, delimiter: str = ','):
         if name_map is None:
             name_map = {}
         if type_map is None:
             type_map = {}
         self.path = os.path.realpath(path)
+        self.delimiter = delimiter
         self.headers = self._init_headers()
         self.columns = Columns(self.headers, name_map, type_map)
     def _init_headers(self):
         with open(self.path, newline='') as handle:
-            csv_data = csv.reader(handle)
+            csv_data = csv.reader(handle, delimiter=self.delimiter)
             return next(csv_data)
 
 class TempLocation:
@@ -281,6 +285,8 @@ def get_args():
                         help='Map CSV header names to Parquet column names')
     parser.add_argument('--types', nargs='*',
                         help='Map CSV header names to Parquet types')
+    parser.add_argument('--delimiter', default=",",
+                        help='Field delimiter')
     args = parser.parse_args()
     try:
         args.column_map = list2dict(args.column_map)
@@ -311,7 +317,7 @@ SELECT
 '''.format(parquet_output)
     column_lines = [column.line(n) for n, column in enumerate(columns)]
     script += ',\n'.join(column_lines) + '\n'
-    script += 'FROM dfs.`{}`\n'.format(csv_input)
+    script += 'FROM TABLE(dfs.`{}`(type=>\'text\', fieldDelimiter => \'{}\'))\n'.format(csv_input, args.delimiter)
     script += 'OFFSET 1\n'
     return script
     
@@ -326,7 +332,7 @@ if __name__ == "__main__":
     if os.path.exists(args.parquet_output):
         sys.stderr.write('Output location "{}" already exists. Rename or delete before running again.\n'.format(args.parquet_output))
         sys.exit(1)
-    csv_source = CsvSource(args.csv_input, args.column_map, args.types)
+    csv_source = CsvSource(args.csv_input, args.column_map, args.types, args.delimiter)
     drill = DrillInstallation()
     drill_script = drill.build_script(csv_source, args.parquet_output)
     try:

--- a/csv2parquet
+++ b/csv2parquet
@@ -317,7 +317,7 @@ SELECT
 '''.format(parquet_output)
     column_lines = [column.line(n) for n, column in enumerate(columns)]
     script += ',\n'.join(column_lines) + '\n'
-    script += 'FROM TABLE(dfs.`{}`(type=>\'text\', fieldDelimiter => \'{}\'))\n'.format(csv_input, args.delimiter)
+    script += 'FROM TABLE(dfs.`{}`(type=>\'text\', fieldDelimiter=>\'{}\'))\n'.format(csv_input, args.delimiter)
     script += 'OFFSET 1\n'
     return script
     

--- a/test/test_csv2parquet.py
+++ b/test/test_csv2parquet.py
@@ -96,7 +96,7 @@ columns[5] as `Volume`,
 columns[6] as `Ex-Dividend`,
 CASE when columns[7]='Split Ratio' then CAST(NULL AS FLOAT) else CAST(columns[7] as FLOAT) end as `Split Ratio`,
 CASE when columns[8]='Adj. Open' then CAST(NULL AS DOUBLE) else CAST(columns[8] as DOUBLE) end as `Adj Open`
-FROM dfs.`/path/to/input.csv`
+FROM TABLE(dfs.`/path/to/input.csv`(type=>'text', fieldDelimiter => ','))
 OFFSET 1
 '''.strip()
         columns = [

--- a/test/test_csv2parquet.py
+++ b/test/test_csv2parquet.py
@@ -96,7 +96,7 @@ columns[5] as `Volume`,
 columns[6] as `Ex-Dividend`,
 CASE when columns[7]='Split Ratio' then CAST(NULL AS FLOAT) else CAST(columns[7] as FLOAT) end as `Split Ratio`,
 CASE when columns[8]='Adj. Open' then CAST(NULL AS DOUBLE) else CAST(columns[8] as DOUBLE) end as `Adj Open`
-FROM TABLE(dfs.`/path/to/input.csv`(type=>'text', fieldDelimiter => ','))
+FROM TABLE(dfs.`/path/to/input.csv`(type=>'text', fieldDelimiter=>','))
 OFFSET 1
 '''.strip()
         columns = [


### PR DESCRIPTION
As per https://docs.python.org/3/library/os.html#os.rename

"The operation may fail on some Unix flavors if src and dst are on different filesystems." 

I came across this trying to use csv2parquet across different mounts on a linux system, swapping to shutil.move fixed my issues and seems to be a more robust move operation.